### PR TITLE
Add Haskell dynamic code reload template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
+dist-newstyle/

--- a/Dynamic.hs
+++ b/Dynamic.hs
@@ -1,0 +1,4 @@
+module Dynamic where
+
+greet :: IO ()
+greet = putStrLn "Hello from dynamic code!"

--- a/Dynamic.hs
+++ b/Dynamic.hs
@@ -1,4 +1,4 @@
 module Dynamic where
 
 greet :: IO ()
-greet = putStrLn "Hello from dynamic code!"
+greet = putStrLn "Hello from dynamic code 11!"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# mqtt-automate
+# Dynamic Reload Example
+
+This is a minimal Haskell application demonstrating how to use the
+[`hint`](https://hackage.haskell.org/package/hint) interpreter to reload
+code whenever a source file changes. The `reloader` executable watches
+`Dynamic.hs` and executes the `greet` function each time the file is
+modified.
+
+## Running
+
+```bash
+stack build
+stack run
+```
+
+Modify `Dynamic.hs` while the program runs to see it reload and execute
+the new code.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,7 +5,7 @@ module Main where
 import Control.Concurrent (threadDelay)
 import Control.Exception (IOException, try)
 import Control.Monad (forever, when)
-import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Language.Haskell.Interpreter
 import System.Directory (getModificationTime)
 import System.FSNotify
@@ -34,7 +34,7 @@ main = do
                     Left _ -> pure ()
         _ <- watchDir mgr "." (const True) $ \event ->
             case event of
-                Added path _ -> whenFile path reloadIfNew
+                Added path _ _ -> whenFile path reloadIfNew
                 Modified path _ _ -> whenFile path reloadIfNew
                 _ -> pure ()
         forever $ threadDelay maxBound

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import Control.Concurrent (threadDelay)
+import Control.Monad (forever, when)
+import Language.Haskell.Interpreter
+import System.FSNotify
+import System.FilePath (takeFileName)
+
+watchFile :: FilePath
+watchFile = "Dynamic.hs"
+
+main :: IO ()
+main = withManager $ \mgr -> do
+    putStrLn $ "Watching " ++ watchFile ++ " for changes..."
+    _ <- watchDir mgr "." (const True) $ \event ->
+        when (takeFileName (eventPath event) == watchFile) reload
+    forever $ threadDelay maxBound
+
+reload :: IO ()
+reload = do
+    putStrLn "Reloading..."
+    result <- runInterpreter $ do
+        loadModules [watchFile]
+        setTopLevelModules ["Dynamic"]
+        interpret "greet" (as :: IO ())
+    case result of
+        Left err -> putStrLn $ "Error: " ++ show err
+        Right action -> action

--- a/dynamic-reload.cabal
+++ b/dynamic-reload.cabal
@@ -1,0 +1,18 @@
+cabal-version: >=1.10
+name:           dynamic-reload
+version:        0.1.0.0
+license:        BSD3
+build-type:     Simple
+synopsis:       Template app demonstrating dynamic code reloading with hint
+
+executable reloader
+  main-is: Main.hs
+  hs-source-dirs: app
+  ghc-options: -Wall
+  build-depends:
+      base >=4.7 && <5
+    , hint
+    , fsnotify
+    , directory
+    , filepath
+  default-language: Haskell2010

--- a/dynamic-reload.cabal
+++ b/dynamic-reload.cabal
@@ -15,4 +15,5 @@ executable reloader
     , fsnotify
     , directory
     , filepath
+    , time
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -1,0 +1,18 @@
+name: dynamic-reload
+version: 0.1.0.0
+license: BSD3
+build-type: Simple
+synopsis: Template app demonstrating dynamic code reloading with hint
+
+executables:
+  reloader:
+    main: Main.hs
+    source-dirs: app
+    ghc-options: -Wall
+    dependencies:
+      - base >= 4.7 && < 5
+      - hint
+      - fsnotify
+      - directory
+      - filepath
+

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,3 @@
+resolver: lts-20.26
+packages:
+- .


### PR DESCRIPTION
## Summary
- Set up stack/cabal configuration for `dynamic-reload` example
- Implement watcher that uses `hint` to reload and run `greet` when `Dynamic.hs` changes
- Provide initial `Dynamic.hs` and usage instructions

## Testing
- `stack build` *(fails: command not found)*
- `cabal build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb45794b08330b4e1272bb918242e