### PR TITLE
feat: add reactive MQTT client

### DIFF
--- a/Dynamic.hs
+++ b/Dynamic.hs
@@ -1,4 +1,15 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Dynamic module defining MQTT subscriptions and handlers.
 module Dynamic where
 
-greet :: IO ()
-greet = putStrLn "Hello from dynamic code 11!"
+-- | Topic filters to subscribe to. Each entry is an MQTT topic filter.
+subscriptions :: [String]
+subscriptions = ["sensors/temperature", "alerts/#"]
+
+-- | Reaction to an incoming MQTT message.
+--   The first argument is the topic on which the message was received,
+--   the second argument is the textual payload.
+onMessage :: String -> String -> IO ()
+onMessage topic payload =
+    putStrLn $ "Received on " ++ topic ++ ": " ++ payload

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Dynamic Reload Example
 
-This is a minimal Haskell application demonstrating how to use the
+This project is a minimal reactive MQTT client. It uses the
 [`hint`](https://hackage.haskell.org/package/hint) interpreter to reload
-code whenever a source file changes. The `reloader` executable watches
-`Dynamic.hs` and executes the `greet` function each time the file is
-modified.
+code whenever `Dynamic.hs` changes. The `Dynamic` module specifies which
+topics to subscribe to and how to react to incoming messages; the running
+client updates its subscriptions and callbacks on the fly.
 
 ## Running
 
@@ -13,5 +13,6 @@ stack build
 stack run
 ```
 
-Modify `Dynamic.hs` while the program runs to see it reload and execute
-the new code.
+Modify `Dynamic.hs` while the program runs to change subscriptions or
+message handling behaviour. Each save triggers a reload and the new
+definitions take effect without restarting the client.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -13,7 +13,7 @@ import System.FilePath (takeFileName)
 import Data.Time.Clock (UTCTime)
 import qualified Data.Text as T
 import qualified Data.ByteString.Lazy.Char8 as BL8
-import Network.MQTT.Client (MQTTClient, mqttConfig, connectURI, subscribe, MessageCallback(..))
+import Network.MQTT.Client (MQTTClient, mqttConfig, connectURI, subscribe, MessageCallback(..), _msgCB)
 import Network.MQTT.Types (QoS(..))
 import Network.URI (parseURI)
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,20 +5,56 @@ module Main where
 import Control.Concurrent (threadDelay)
 import Control.Exception (IOException, try)
 import Control.Monad (forever, when)
-import Data.IORef (newIORef, readIORef, writeIORef)
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import Language.Haskell.Interpreter
 import System.Directory (getModificationTime)
 import System.FSNotify
 import System.FilePath (takeFileName)
 import Data.Time.Clock (UTCTime)
+import qualified Data.Text as T
+import qualified Data.ByteString.Lazy.Char8 as BL8
+import Network.MQTT.Client
+import Network.MQTT.Types (QoS(..))
+import Network.URI (parseURI)
 
 watchFile :: FilePath
 watchFile = "Dynamic.hs"
+
+-- | Reload the dynamic module and update subscriptions and handlers.
+reload :: Client -> IORef (String -> String -> IO ()) -> IO ()
+reload client handlerRef = do
+    putStrLn "Reloading..."
+    result <- runInterpreter $ do
+        loadModules [watchFile]
+        setTopLevelModules ["Dynamic"]
+        subs <- interpret "subscriptions" (as :: [String])
+        handler <- interpret "onMessage" (as :: String -> String -> IO ())
+        return (subs, handler)
+    case result of
+        Left err -> putStrLn $ "Error: " ++ show err
+        Right (subs, handler) -> do
+            writeIORef handlerRef handler
+            -- subscribe to new topics
+            _ <- subscribe client $ zip (T.pack <$> subs) (repeat QoS0)
+            return ()
 
 main :: IO ()
 main = do
     initialTime <- getModificationTime watchFile
     lastTimeRef <- newIORef initialTime
+    handlerRef <- newIORef (\_ _ -> pure ())
+
+    -- set up MQTT client with dynamic callback
+    let cb _ topic payload = do
+            h <- readIORef handlerRef
+            h (T.unpack topic) (BL8.unpack payload)
+    let cfg = mqttConfig { _msgCB = SimpleCallback cb }
+    let Just uri = parseURI "mqtt://test.mosquitto.org"
+    client <- connectURI cfg uri
+
+    -- initial load of dynamic module
+    reload client handlerRef
+
     withManager $ \mgr -> do
         putStrLn $ "Watching " ++ watchFile ++ " for changes..."
         let whenFile path action =
@@ -30,7 +66,7 @@ main = do
                         lastTime <- readIORef lastTimeRef
                         when (newTime > lastTime) $ do
                             writeIORef lastTimeRef newTime
-                            reload
+                            reload client handlerRef
                     Left _ -> pure ()
         _ <- watchDir mgr "." (const True) $ \event ->
             case event of
@@ -38,14 +74,3 @@ main = do
                 Modified path _ _ -> whenFile path reloadIfNew
                 _ -> pure ()
         forever $ threadDelay maxBound
-
-reload :: IO ()
-reload = do
-    putStrLn "Reloading..."
-    result <- runInterpreter $ do
-        loadModules [watchFile]
-        setTopLevelModules ["Dynamic"]
-        interpret "greet" (as :: IO ())
-    case result of
-        Left err -> putStrLn $ "Error: " ++ show err
-        Right action -> action

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -13,7 +13,7 @@ import System.FilePath (takeFileName)
 import Data.Time.Clock (UTCTime)
 import qualified Data.Text as T
 import qualified Data.ByteString.Lazy.Char8 as BL8
-import Network.MQTT.Client
+import Network.MQTT.Client (MQTTClient, mqttConfig, connectURI, subscribe, MessageCallback(..))
 import Network.MQTT.Types (QoS(..))
 import Network.URI (parseURI)
 
@@ -21,7 +21,7 @@ watchFile :: FilePath
 watchFile = "Dynamic.hs"
 
 -- | Reload the dynamic module and update subscriptions and handlers.
-reload :: Client -> IORef (String -> String -> IO ()) -> IO ()
+reload :: MQTTClient -> IORef (String -> String -> IO ()) -> IO ()
 reload client handlerRef = do
     putStrLn "Reloading..."
     result <- runInterpreter $ do

--- a/dynamic-reload.cabal
+++ b/dynamic-reload.cabal
@@ -16,7 +16,7 @@ executable reloader
     , directory
     , filepath
     , time
-    , mqtt-client
+    , net-mqtt
     , text
     , bytestring
     , network-uri

--- a/dynamic-reload.cabal
+++ b/dynamic-reload.cabal
@@ -16,4 +16,8 @@ executable reloader
     , directory
     , filepath
     , time
+    , mqtt-client
+    , text
+    , bytestring
+    , network-uri
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -15,4 +15,8 @@ executables:
       - fsnotify
       - directory
       - filepath
+      - mqtt-client
+      - text
+      - bytestring
+      - network-uri
 

--- a/package.yaml
+++ b/package.yaml
@@ -15,7 +15,7 @@ executables:
       - fsnotify
       - directory
       - filepath
-      - mqtt-client
+      - net-mqtt
       - text
       - bytestring
       - network-uri


### PR DESCRIPTION
## Summary
- watch Dynamic.hs for topic subscriptions and message handlers
- connect to a public MQTT broker and reload on source changes
- document reactive MQTT behaviour in README

## Testing
- `stack build` *(fails: command not found)*
- `cabal build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc55827d88330890b406a00421a30